### PR TITLE
Use normal Spotify behavior for track position

### DIFF
--- a/index.php
+++ b/index.php
@@ -68,7 +68,6 @@ function add_track_to_playlist(string $accessToken, string $playlistId, string $
     $endpoint = "https://api.spotify.com/v1/playlists/$playlistId/tracks?";
     $endpoint .= http_build_query([
         'uris' => $trackId,
-        'position' => 0,
     ]);
 
     $ok = file_get_contents($endpoint, false, $context);


### PR DESCRIPTION
`position` attribute is optional, let's remove it to use the normal Spotify behavior and add tracks at the end of the playlist :wink:

See https://developer.spotify.com/documentation/web-api/reference/playlists/add-tracks-to-playlist/