### PR TITLE
add new intl-fr url

### DIFF
--- a/index.php
+++ b/index.php
@@ -208,6 +208,10 @@ if ('event_callback' === $payload['type']) {
             continue;
         }
 
+        if ($parts[0] === 'intl-fr') {
+            array_shift($parts);
+        }
+
         switch ($parts[0]) {
             case 'track':
                 $trackIds[] = 'spotify:track:'.$parts[1];


### PR DESCRIPTION
It seems that spotify add a intl-fr/ to their url sometimes (surely intl-{locale}, but I don't have this behavior for now).

So it's something like
```
https://open.spotify.com/intl-fr/track/3DS1N5ZXsSzoD7u8uT2UAT?si=1d2e24fb98fa4abd
```

instead of 
```
https://open.spotify.com/track/3DS1N5ZXsSzoD7u8uT2UAT?si=3633e3f3b0c14fd1
```

So I just get rid of the intl-fr thingy.

Absolutely not tested, and I don't know PHP.